### PR TITLE
JDKMon 16.0.5

### DIFF
--- a/downloads/downloads.json
+++ b/downloads/downloads.json
@@ -408,19 +408,19 @@
     "files": [
       {
         "name": "MSI Installer (Windows)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.4/JDKMon-16.0.4.msi",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.5/JDKMon-16.0.5.msi",
         "fileName": "",
         "package": "MSI"
       },
       {
         "name": "PKG Installer (Mac)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.4/JDKMon-16.0.4.pkg",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.5/JDKMon-16.0.5.pkg",
         "fileName": "",
         "package": "PKG"
       },
       {
         "name": "DEB Installer (Linux)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.4/jdkmon_16.0.4-1_amd64.deb",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/16.0.5/jdkmon_16.0.5-1_amd64.deb",
         "fileName": "",
         "package": "DEB"
       }


### PR DESCRIPTION
Updated JDKMon to 16.0.5 with support for Eclipse Temurin