### PR TITLE
Updated binjr download links to v3.3.0 

### DIFF
--- a/downloads/downloads.json
+++ b/downloads/downloads.json
@@ -434,35 +434,35 @@
     "repository": "https://github.com/binjr/binjr",
     "downloadType": "APPLICATION",
     "createdOn": "2021-08-18",
-    "modifiedOn": "2021-08-18",
+    "modifiedOn": "2021-09-17",
     "files": [
       {
         "name": "Windows (MSI)",
-        "url": "https://github.com/binjr/binjr/releases/download/v3.2.0/binjr-3.2.0_windows-amd64.msi",
+        "url": "https://github.com/binjr/binjr/releases/download/v3.3.0/binjr-3.3.0_windows-amd64.msi",
         "fileName": "",
         "package": "MSI"
       }, 
       {
         "name": "Windows (ZIP)",
-        "url": "https://github.com/binjr/binjr/releases/download/v3.2.0/binjr-3.2.0_windows-amd64.zip",
+        "url": "https://github.com/binjr/binjr/releases/download/v3.3.0/binjr-3.3.0_windows-amd64.zip",
         "fileName": "",
         "package": "ZIP"
       },
       {
-        "name": "macOS (DMG)",
-        "url": "https://github.com/binjr/binjr/releases/download/v3.2.0/binjr-3.2.0_mac-x86_64.dmg",
+        "name": "macOS (PKG)",
+        "url": "https://github.com/binjr/binjr/releases/download/v3.3.0/binjr-3.3.0_mac-x86_64.pkg",
         "fileName": "",
-        "package": "DMG"
+        "package": "PKG"
       },
       {
         "name": "macOS (TAR.GZ)",
-        "url": "https://github.com/binjr/binjr/releases/download/v3.2.0/binjr-3.2.0_mac-x86_64.tar.gz",
+        "url": "https://github.com/binjr/binjr/releases/download/v3.3.0/binjr-3.3.0_mac-x86_64.tar.gz",
         "fileName": "",
         "package": "TAR.GZ"
       },
       {
         "name": "Linux (TAR.GZ)",
-        "url": "https://github.com/binjr/binjr/releases/download/v3.2.0/binjr-3.2.0_linux-amd64.tar.gz",
+        "url": "https://github.com/binjr/binjr/releases/download/v3.3.0/binjr-3.3.0_linux-amd64.tar.gz",
         "fileName": "",
         "package": "TAR.GZ"
       }

--- a/realworld/binjr/readme.md
+++ b/realworld/binjr/readme.md
@@ -27,8 +27,8 @@ Behind the scene, _binjr_ uses Apache Lucene to index data from log files; meani
 language to hack through vast quantities logged events.
 
 It also allows _binjr_ to open log files of any size; unlike most text editors which will fail to load multi
-gigabytes-sized files as they try to fit it all in memory, _binjr_ will happily index those and present a paginated view so that memory usage remains reasonable, while the backing index ensures navigating and searching is lighting
-fast.
+gigabytes-sized files as they try to fit it all in memory, _binjr_ will happily index those and present a paginated view
+so that memory usage remains reasonable, while the backing index ensures navigating and searching is lightning fast.
 
 ![Screen 2](screen2.png)
 
@@ -40,5 +40,5 @@ local solution (the data never needs to be pushed to the cloud - or anywhere els
 setup nor maintenance to speak of.
  
 > _binjr_ is developed and released as Free and Open Source Software, under the [Apache License version 2.0](https://github.com/binjr/binjr/blob/master/LICENSE.md).  
-> You can find all the source code and the issue tracker at [https://github.com/binjr/binjr](https://github.com/binjr/binjr)  
+> You can find the source code and the issue tracker at [https://github.com/binjr/binjr](https://github.com/binjr/binjr)  
 > More information, user guide and download links are available at [https://binjr.eu](https://binjr.eu)


### PR DESCRIPTION
This PR updates the download links for binjr to the latest version.
Also fixes a couple of typos in the "3rd party app" readme.