### PR TITLE
JDKMon 17.0.18

### DIFF
--- a/downloads/downloads.json
+++ b/downloads/downloads.json
@@ -416,41 +416,41 @@
       "g.grunwald"
     ],
     "createdOn": "2021-07-06",
-    "modifiedOn": "2021-12-08",
+    "modifiedOn": "2021-12-17",
     "files": [
       {
         "name": "MSI Installer (Windows)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/JDKMon-17.0.17.msi",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.18/JDKMon-17.0.18.msi",
         "fileName": "",
         "package": "MSI"
       },
       {
         "name": "PKG Installer (Mac)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/JDKMon-17.0.17.pkg",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.18/JDKMon-17.0.18.pkg",
         "fileName": "",
         "package": "PKG"
       },
       {
         "name": "PKG Installer (Mac M1)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/JDKMon-17.0.17-aarch64.pkg",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.18/JDKMon-17.0.18-aarch64.pkg",
         "fileName": "",
         "package": "PKG"
       },
       {
         "name": "DEB Installer (Linux)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/jdkmon_17.0.17-1_amd64.deb",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.18/jdkmon_17.0.18-1_amd64.deb",
         "fileName": "",
         "package": "DEB"
       },
       {
         "name": "RPM Installer (Linux)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/jdkmon-17.0.17-1.x86_64.rpm",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/jdkmon-17.0.18-1.x86_64.rpm",
         "fileName": "",
         "package": "RPM"
       },
       {
         "name": "DEB Installer (Linux ARM64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/jdkmon_17.0.17-1_arm64.deb",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.17/jdkmon_17.0.18-1_arm64.deb",
         "fileName": "",
         "package": "DEB"
       }


### PR DESCRIPTION
- Experimental support for TCK tested distributions
- Check for known vulnerabilities