### PR TITLE
Have links in FXSkins and JMetro be clickable

### DIFF
--- a/libraries/fxskins/readme.md
+++ b/libraries/fxskins/readme.md
@@ -1,5 +1,5 @@
-If you want to use FXSkins, the best place to start is by checking out the documentation page: https://pixelduke.com/fxskins/
+If you want to use FXSkins, the best place to start is by checking out the documentation page: [https://pixelduke.com/fxskins/](https://pixelduke.com/fxskins/)
 
-- The Github repository is located at: https://github.com/dukke/FXSkins  
+- The GitHub repository is located at: [https://github.com/dukke/FXSkins](https://github.com/dukke/FXSkins)  
 
-- The issue tracker is here: https://github.com/dukke/FXSkins/issues
+- The issue tracker is here: [https://github.com/dukke/FXSkins/issues](https://github.com/dukke/FXSkins/issues)

--- a/libraries/jmetro/readme.md
+++ b/libraries/jmetro/readme.md
@@ -1,5 +1,5 @@
-If you want to use JMetro, the best place to start is by checking out the documentation page: https://pixelduke.com/java-javafx-theme-jmetro/
+If you want to use JMetro, the best place to start is by checking out the documentation page: [https://pixelduke.com/java-javafx-theme-jmetro/](https://pixelduke.com/java-javafx-theme-jmetro/)
 
-- The Github repository is located at: https://github.com/JFXtras/jfxtras-styles  
+- The GitHub repository is located at: [https://github.com/JFXtras/jfxtras-styles](https://github.com/JFXtras/jfxtras-styles)  
 
-- The issue tracker is here: https://github.com/JFXtras/jfxtras-styles/issues
+- The issue tracker is here: [https://github.com/JFXtras/jfxtras-styles/issues](https://github.com/JFXtras/jfxtras-styles/issues)


### PR DESCRIPTION
The links in the FXSkins and JMetro description were just text and couldn't be clicked. I've changed that.