### PR TITLE
JDKMon 17.0.85

### DIFF
--- a/downloads/downloads.json
+++ b/downloads/downloads.json
@@ -430,47 +430,47 @@
       "g.grunwald"
     ],
     "createdOn": "2021-09-27",
-    "modifiedOn": "2023-11-13",
+    "modifiedOn": "2023-11-20",
     "files": [
       {
         "name": "MSI Installer (Windows Intel)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/JDKMon-17.0.83.msi",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/JDKMon-17.0.85.msi",
         "fileName": "",
         "package": "MSI"
       },
       {
         "name": "PKG Installer (Mac Intel)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/JDKMon-17.0.83.pkg",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/JDKMon-17.0.85.pkg",
         "fileName": "",
         "package": "PKG"
       },
       {
         "name": "PKG Installer (Mac aarch64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/JDKMon-17.0.83-aarch64.pkg",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/JDKMon-17.0.85-aarch64.pkg",
         "fileName": "",
         "package": "PKG"
       },
       {
         "name": "DEB Installer (Linux x64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/jdkmon_17.0.83-1_amd64.deb",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/jdkmon_17.0.85-1_amd64.deb",
         "fileName": "",
         "package": "DEB"
       },
       {
         "name": "RPM Installer (Linux x64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/jdkmon-17.0.83-1.x86_64.rpm",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/jdkmon-17.0.85-1.x86_64.rpm",
         "fileName": "",
         "package": "RPM"
       },
       {
         "name": "DEB Installer (Linux aarch64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/jdkmon_17.0.83-1_arm64.deb",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/jdkmon_17.0.85-1_arm64.deb",
         "fileName": "",
         "package": "DEB"
       },
       {
         "name": "RPM Installer (Linux aarch64)",
-        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.83/jdkmon-17.0.83-1.aarch64.rpm",
+        "url": "https://github.com/HanSolo/JDKMon/releases/download/17.0.85/jdkmon-17.0.85-1.aarch64.rpm",
         "fileName": "",
         "package": "RPM"
       }


### PR DESCRIPTION
- Added support for CVSS 4.0
- Make use of NVD API 2.0