### PR TITLE
Remove unnecessary line breaks

### DIFF
--- a/people/e.ryzhikov/readme.md
+++ b/people/e.ryzhikov/readme.md
@@ -1,2 +1,1 @@
-Software architect, Java and Scala enthusiast. JavaOne Rockstar, and Duke's Choice award 
-winner. Gluon co-founder.
+Software architect, Java and Scala enthusiast. JavaOne Rockstar, and Duke's Choice award winner. Gluon co-founder.


### PR DESCRIPTION
The change focuses on refining the description found in the readme.md under the people/e.ryzhikov directory. The previous two line details were merged into a single coherent sentence, offering a concise summary.